### PR TITLE
Return tftest obj if no command is passed

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,10 @@ With the use of this plugin, users can run Terragrunt and Terraform commands wit
       - `basedir`: Base directory for `tfdir` (defaults to cwd)
       - `env`: Environment variables to pass to the command
       - `skip_teardown`: Skips running fixture's teardown logic
-      - `use_cache`: If `True`, gets command output from `terra_cache` fixture
+      - `get_cache`: If `True`, gets command output from `terra_cache` fixture
       - `extra_args`: Dictionary of extra arguments to pass to the command
    - Setup: Updates cache with selected kwargs provided
-   - Yield: If `use_cache` is `True`, yields output for the input `command` from the `terra_cache` fixture. If `use_cache` is `False`, yields output from the execution of the command
+   - Yield: If `get_cache` is `True`, yields output for the input `command` from the `terra_cache` fixture. If `get_cache` is `False`, yields output from the execution of the command
    - Teardown: Runs `terraform destroy -auto-approve` on the input `tfdir` directory
 
 `terra_factory`: 
@@ -28,17 +28,17 @@ With the use of this plugin, users can run Terragrunt and Terraform commands wit
       - `basedir`: Base directory for `tfdir` (defaults to cwd)
       - `env`: Environment variables to pass to the command
       - `skip_teardown`: Skips running fixture's teardown logic
-      - `use_cache`: If `True`, gets command output from `terra_cache` fixture
+      - `get_cache`: If `True`, gets command output from `terra_cache` fixture
       - `extra_args`: Dictionary of extra arguments to pass to the command
    - Setup: Updates cache with selected kwargs provided
-   - Yield: If `use_cache` is `True`, yields output for the input `command` from the `terra_cache` fixture. If `use_cache` is `False`, yields output from the execution of the command
+   - Yield: If `get_cache` is `True`, yields output for the input `command` from the `terra_cache` fixture. If `get_cache` is `False`, yields output from the execution of the command
    - Teardown: Runs `terraform destroy -auto-approve` on every factory instance's input `tfdir` directory
  
 `terra_cache`: 
    - Scope: Session
    - Setup: Runs `terraform init` on the specified directory
-   - Yield: Factory fixture that returns a `tftest.TerraformTest` object that can run subsequent Terraform commands with
-   - Teardown: Runs `terraform destroy -auto-approve` on the specified directory
+   - Yield: Factory fixture that returns a `tftest.TerraformTest` or `tftest.TerragruntTest` object that can run subsequent methods with
+   - Teardown: Clears cache dictionary
 
 ## CLI Arguments
 
@@ -49,6 +49,30 @@ With the use of this plugin, users can run Terragrunt and Terraform commands wit
    ```
  
 ## Examples
+
+### Returns tftest object
+
+`terra`
+```
+import pytest
+
+@pytest.mark.parametrize("terra", [
+   {
+      "binary": "terraform",
+      "tfdir": "bar",
+      "env": {
+         "TF_LOG": "DEBUG"
+      },
+      "skip_teardown": False,
+   }
+], indirect=['terra'])
+def test_terra_param(terra):
+   terra.apply(auto_approve=True)
+   output = terra.output()
+   assert output["doo"] == "foo"
+```
+
+### Run commands within fixture:
 
 `terra`
 ```
@@ -63,7 +87,7 @@ import pytest
          "TF_LOG": "DEBUG"
       },
       "skip_teardown": False,
-      "use_cache": False,
+      "get_cache": False,
       "extra_args": {"state_out": "/foo"},
    }
 ], indirect=['terra'])

--- a/terra_fixt.py
+++ b/terra_fixt.py
@@ -1,6 +1,7 @@
 import pytest
 import tftest
 import logging
+import os
 
 log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)

--- a/terra_fixt.py
+++ b/terra_fixt.py
@@ -16,6 +16,7 @@ def pytest_addoption(parser):
 
 class TfTestCache:
     def __init__(self, **kwargs):
+        self.cache = {}
         if kwargs["binary"].endswith("terraform"):
             self.instance = tftest.TerraformTest(**kwargs)
         elif kwargs["binary"].endswith("terragrunt"):
@@ -24,13 +25,16 @@ class TfTestCache:
     def __getattr__(self, name):
         return self.instance.__getattribute__(name)
 
-    def get_cache(self, cmd):
-        return getattr(self, f"cached_{cmd}")
+    def run(self, command, put_cache=True, get_cache=False, **extra_args):
+        command = command.replace(" ", "_")
+        if get_cache:
+            if command in self.cache:
+                return self.cache[command]
 
-    def run_terra_cmd(self, cmd, **extra_args):
-        cmd = cmd.replace(" ", "_")
-        out = getattr(self, cmd)(**extra_args)
-        setattr(self, f"cached_{cmd}", out)
+        out = getattr(self, command)(**extra_args)
+
+        if put_cache:
+            self.cache[command] = out
 
         return out
 

--- a/terra_fixt.py
+++ b/terra_fixt.py
@@ -45,10 +45,20 @@ def terra_cache():
 
     def _cache(**kwargs):
         if kwargs != {}:
+            if not kwargs["tfdir"].startswith("/"):
+                kwargs["tfdir"] = os.path.join(
+                    kwargs.get("basedir", os.getcwd()), kwargs["tfdir"]
+                )
 
-            cache = TfTestCache(**kwargs)
-            terras[cache.tfdir] = cache
-            return cache
+            if kwargs["tfdir"] in terras.keys():
+                cache_cls = terras[kwargs["tfdir"]]
+                for key, value in kwargs.items():
+                    setattr(cache_cls, key, value)
+                log.debug(cache_cls.binary)
+            else:
+                terras[kwargs["tfdir"]] = TfTestCache(**kwargs)
+
+            return terras[kwargs["tfdir"]]
 
         else:
             return terras

--- a/terra_fixt.py
+++ b/terra_fixt.py
@@ -56,6 +56,7 @@ def terra_cache():
 
 terra_kwargs = ["command", "skip_teardown", "use_cache", "extra_args"]
 
+
 @pytest.fixture
 def terra(request, terra_cache):
     tftest_kwargs = {
@@ -102,13 +103,15 @@ def terra_factory(request, terra_cache):
             skip = cfg.get("skip_teardown", False)
         if not skip:
             teardowns.append(terra_cls.tfdir)
-        
+
         if cfg.get("command"):
             if cfg.get("use_cache", False):
                 log.info("Getting results from cache")
                 return terra_cls.get_cache(cfg["command"])
             else:
-                return terra_cls.run_terra_cmd(cfg["command"], **cfg.get("extra_args", {}))
+                return terra_cls.run_terra_cmd(
+                    cfg["command"], **cfg.get("extra_args", {})
+                )
         else:
             return terra_cls
 

--- a/tests/data.py
+++ b/tests/data.py
@@ -1,24 +1,23 @@
 all_kwargs = [
     {
         "binary": "terraform",
-        "basedir": "fixture",
+        "basedir": "/fixture",
         "tfdir": "bar",
         "env": {},
-        "tg_run_all": False,
         "command": "apply",
         "skip_teardown": False,
-        "use_cache": False,
+        "get_cache": False,
         "extra_args": {"auto_approve": True},
     },
     {
         "binary": "terragrunt",
-        "basedir": "fixture",
+        "basedir": "/fixture",
         "tfdir": "bar",
         "env": {},
         "tg_run_all": False,
         "command": "apply",
         "skip_teardown": False,
-        "use_cache": False,
+        "get_cache": False,
         "extra_args": {"auto_approve": True},
     },
 ]

--- a/tests/test_terra_cache.py
+++ b/tests/test_terra_cache.py
@@ -38,7 +38,6 @@ def test_add_cache(pytester):
 def test_update_cache(pytester):
     pytester.makepyfile(
         """
-    from tftest import TerragruntTest
     def test_foo(terra_cache):
         data = {
             "binary": "terraform",
@@ -47,10 +46,11 @@ def test_update_cache(pytester):
         }
         terra_cache(**data)
 
-        data["binary"] = "terragrunt"
+        updated_env = {"baz": "doo"}
+        data["env"] = updated_env
         terra_cache(**data)
 
-        assert isinstance(terra_cache()["foo/bar"].instance, TerragruntTest)
+        assert terra_cache()["foo/bar"].env == updated_env
     """
     )
     reprec = pytester.inline_run()

--- a/tests/test_tftest_cache.py
+++ b/tests/test_tftest_cache.py
@@ -8,8 +8,8 @@ def test_get_cache(cmd):
 
     cache = TfTestCache(binary="terraform", tfdir="foo")
     with patch(f"tftest.TerraformTest.{cmd}") as mock_cmd:
-        output = cache.run_terra_cmd(cmd)
-        cached_output = cache.get_cache(cmd)
+        output = cache.run(cmd)
+        cached_output = cache.run(cmd, get_cache=True)
 
         assert output == cached_output
 


### PR DESCRIPTION
If `command` kwarg is not passed within `terra` and `terra_factory` fixtures, the tftest object is returned. This allows the tftest object to be used for subsequent methods within pytest tests/fixtures.