### PR TITLE
Change terra fixt from func to session scope

### DIFF
--- a/terra_fixt.py
+++ b/terra_fixt.py
@@ -72,7 +72,7 @@ def terra_cache():
 terra_kwargs = ["command", "skip_teardown", "get_cache", "put_cache", "extra_args"]
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def terra(request, terra_cache):
     tftest_kwargs = {
         key: value for key, value in request.param.items() if key not in terra_kwargs


### PR DESCRIPTION
For use cases where the `terra` fixt is parameterized within the special `pytest_generate_tests()` pytest function, any fixtures that depend on the the `terra` fixture will be passed  the`terra` fixture with default function scope. This is an issue for fixtures that are broader than the function scope. It also makes sense to move `terra` to be a session scoped fixture given the `terra` fixture will most often be reused by multiple tests without having to teardown the Terraform/Terragrunt configurations after every test.